### PR TITLE
Add Orientation Property  to dfs2 object

### DIFF
--- a/dhitools/dfs.py
+++ b/dhitools/dfs.py
@@ -78,7 +78,7 @@ class _Dfs(object):
         """
         print("Input file: {}".format(self.filename))
         print("Time start = {}".format(dt.datetime.strftime(self.start_datetime,
-                                                            "%d/%m/%Y %H:%M:%S")))
+                                                            "%Y/%m/%d %H:%M:%S")))
         print("Number of timesteps = {}".format(self.number_tstep))
         print("Timestep = {}".format(self.timestep))
         print("Number of items = {}".format(self.num_items))

--- a/dhitools/dfs.py
+++ b/dhitools/dfs.py
@@ -97,6 +97,7 @@ class _Dfs(object):
             print("(del_X, del_Y) = ({}, {})".format(self.del_x, self.del_y))
             print("(X_min, Y_min) = ({}, {})".format(self.x_min, self.y_min))
             print("(X_max, Y_max) = ({}, {})".format(self.x_max, self.y_max))
+            print("Angle to North = {} ".format(self.orientation))
             print("")
 
         print("Items:")
@@ -333,6 +334,7 @@ class Dfs2(_Dfs):
         self.del_y = sa.Dy
         self.y_count = sa.YCount
         self.y_max = self.y_min + (self.del_y * self.y_count)
+        self.orientation = fi.Projection.Orientation
         self.gridshape = (self.y_count, self.x_count)
 
         self.X, self.Y = np.meshgrid(np.arange(self.x_min, self.x_max, self.del_x),

--- a/dhitools/dfsu.py
+++ b/dhitools/dfsu.py
@@ -96,8 +96,13 @@ class Dfsu(mesh.Mesh):
 
         # Time attributes
         self.start_datetime_str = dfsu_object.StartDateTime.Date.ToString()
-        self.start_datetime = dt.datetime.strptime(self.start_datetime_str,
-                                                   '%d/%m/%Y %H:%M:%S %p')
+        dt_start_obj = dfsu_object.StartDateTime
+        self.start_datetime = dt.datetime(year=dt_start_obj.Year,
+                                          month=dt_start_obj.Month,
+                                          day=dt_start_obj.Day,
+                                          hour=dt_start_obj.Hour,
+                                          minute=dt_start_obj.Minute,
+                                          second=dt_start_obj.Second)
         self.timestep = dfsu_object.TimeStepInSeconds
         self.number_tstep = dfsu_object.NumberOfTimeSteps - 1
         self.end_datetime = self.start_datetime + \


### PR DESCRIPTION
Define the orientation of the local grid coordinate system. 
The orientation is the angle in degrees between true north and the coordinate system y-axis in degrees, measured positive clockwise from true north. 

------------------------------------------------------
Dear Rob 

I am adding _create_dfs2 method and this is a tiny property (but important) that would be used in the future. Very happy to contribute this great tool! 
Please leave your comments or suggestions!